### PR TITLE
bugfix SqlActuator.run()方法中漏写了sql.setEntity()，加上该语句

### DIFF
--- a/src/main/java/club/zhcs/titans/utils/db/SqlActuator.java
+++ b/src/main/java/club/zhcs/titans/utils/db/SqlActuator.java
@@ -72,6 +72,7 @@ public class SqlActuator {
 
 	public static <T> T run(Sql sql, Dao dao, Class<T> classOfEntity) {
 		sql.setCallback(Sqls.callback.entity());
+		sql.setEntity(dao.getEntity(classOfEntity));
 		dao.execute(sql);
 		return sql.getObject(classOfEntity);
 	}


### PR DESCRIPTION
bugfix SqlActuator.run()方法中漏写了sql.setEntity()，加上该语句